### PR TITLE
PXPost: if payment is successful make an order; exceptions managed via status

### DIFF
--- a/app/code/community/MageBase/DpsPaymentExpress/Model/Observer.php
+++ b/app/code/community/MageBase/DpsPaymentExpress/Model/Observer.php
@@ -9,7 +9,13 @@ class MageBase_DpsPaymentExpress_Model_Observer
             $result->setShouldProceed(false);
         }
     }
+
+    public function setOrderPaymentPreviewState($observer)
+    {
+        $order = $observer->getPayment()->getOrder();
+        if ($order->getPaymentPreviewState()) {
+            $state = $order->getPaymentPreviewState();
+            $order->setStatus($state);
+        }
+    }
 }
-
-
-

--- a/app/code/community/MageBase/DpsPaymentExpress/etc/config.xml
+++ b/app/code/community/MageBase/DpsPaymentExpress/etc/config.xml
@@ -14,7 +14,9 @@
             <magebasedps_mysql4>
                 <class>MageBase_DpsPaymentExpress_Model_Mysql4</class>
                 <entities>
-                    <debug><table>magebasedps_debug</table></debug>
+                    <debug>
+                        <table>magebasedps_debug</table>
+                    </debug>
                 </entities>
             </magebasedps_mysql4>
         </models>
@@ -60,6 +62,16 @@
                 </types>
             </cc>
         </payment>
+        <events>
+            <sales_order_payment_place_end>
+                <observers>
+                    <magebase_dpspaymentexpress>
+                        <class>magebasedps/observer</class>
+                        <method>setOrderPaymentPreviewState</method>
+                    </magebase_dpspaymentexpress>
+                </observers>
+            </sales_order_payment_place_end>
+        </events>
     </global>
     <frontend>
         <events>
@@ -108,6 +120,7 @@
                 <max_order_total>0</max_order_total>
                 <sort_order>1213</sort_order>
                 <debug>0</debug>
+                <cvv2_not_matched_state>payment_review</cvv2_not_matched_state>
             </magebasedpspxpost>
             <magebasedpspxpay>
                 <active>0</active>

--- a/app/code/community/MageBase/DpsPaymentExpress/etc/system.xml
+++ b/app/code/community/MageBase/DpsPaymentExpress/etc/system.xml
@@ -146,6 +146,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </debug>
+                        <cvv2_not_matched_state translate="label">
+                            <label>CVV2 Not Matched state</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>sales/order_config::getStates</source_model>
+                            <sort_order>520</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </cvv2_not_matched_state>
                     </fields>
                 </magebasedpspxpost>
                 <magebasedpspxpay translate="label" module="magebasedps">


### PR DESCRIPTION
Currently if a transaction is successfully captutured but fails validation for any reason including [CVV2 mismatch](http://www.paymentexpress.com/CVV2_Mandate) Magento's quote is not moved to an order, debug logs and "order failed" emails are relied on to communicate this with store owners. 

The customer is presented an alert with a message similar to "Your transaction has failed, please try again later".

In my experience this leads to a number of issues:
1. The customer has had their expectations mangage incorrectly. The error message is commonly interpreted as funds have not been captured.
2. The store admin staff need a workflow to manage failed emails, somehow manually create or refund the order to process and clear the inconsistency.
3. The customers quote is in an inconsistent state. Each time they retry, if the same error presents they are charged again if they change their cart items the quote is over-written. The `reserved_order_id` does not change.

The root issue, in my opinion, is a lack of feedback.

The gateway docs list the "success" response as the canonical measure if a payment has succeeded or not. http://www.paymentexpress.com/technical_resources/ecommerce_nonhosted/pxpost.html#Success

The crux of this pull request is that if `success=1` an order is created.
There has been no change to the `success=0` behaviour.

If we get a `success=1` response, payment is recorded and the quote moved to an order as payment has been successfully captured.

There is a new admin configuration called "CVV2 Not Matched state" to handle CVV2 related validation failures. This defaults to `payment_review`.
If `Cvc2ResultCode` is `M`, `P` or `U` it is considered to be a match and this setting won't apply. Only `N` or `S`.

If validation fails the order history is updated and state changed as appropriate.

Store owner can build workflows to ensure customer service is handled correctly and most importantly the customer's expectations are correctly managed - they have been charged so they get the appropriate feedback. If the store owner choses to cancel and a `payment_review` state transaction they now have the tools to do this in a controlled manner.

This only effects the PXPost implimentation. I have not reviewed PXPay or the PXFusion code. I have however been running this in a production store for over 3 weeks with no issues.
